### PR TITLE
Allow limiting search to a particular job/run name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,12 +10,12 @@ env:
   EXPECTED_CHECKSUM: 50a2fabfdd276f573ff97ace8b11c5f4
 
 jobs:
-  test:
+  test-single:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - id: single
+      - id: action
         uses: ./
         with:
           ref: target
@@ -31,9 +31,40 @@ jobs:
       - run: test "$EXPECTED" = "$ACTUAL"
         env:
           EXPECTED: ${{ env.EXPECTED_ARTIFACT_ID }}
-          ACTUAL: ${{ steps.single.outputs.artifact_id }}
+          ACTUAL: ${{ steps.action.outputs.artifact_id }}
 
-      - id: multiple
+
+  test-single-with-run-name:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: action
+        uses: ./
+        with:
+          ref: target
+          artifact_name: Banana
+          download: true
+          run_name: manual
+
+      - run: unzip Banana.zip
+
+      - run: md5sum -c <<< "$EXPECTED Banana.txt"
+        env:
+          EXPECTED: ${{ env.EXPECTED_CHECKSUM }}
+
+      - run: test "$EXPECTED" = "$ACTUAL"
+        env:
+          EXPECTED: ${{ env.EXPECTED_ARTIFACT_ID }}
+          ACTUAL: ${{ steps.action.outputs.artifact_id }}
+
+
+  test-multiple:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: action
         uses: ./
         continue-on-error: true
         with:
@@ -43,9 +74,15 @@ jobs:
       - run: test "$EXPECTED" = "$ACTUAL"
         env:
           EXPECTED: multiple-artifacts
-          ACTUAL: ${{ steps.multiple.outputs.error }}
+          ACTUAL: ${{ steps.action.outputs.error }}
 
-      - id: none
+
+  test-none:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: action
         uses: ./
         continue-on-error: true
         with:
@@ -55,4 +92,4 @@ jobs:
       - run: test "$EXPECTED" = "$ACTUAL"
         env:
           EXPECTED: no-artifacts
-          ACTUAL: ${{ steps.none.outputs.error }}
+          ACTUAL: ${{ steps.action.outputs.error }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@
 
 env:
   EXPECTED_ARTIFACT_ID: 1844382885
+  EXPECTED_CHECKSUM: 50a2fabfdd276f573ff97ace8b11c5f4
 
 jobs:
   test:
@@ -25,7 +26,7 @@ jobs:
 
       - run: md5sum -c <<< "$EXPECTED Banana.txt"
         env:
-          EXPECTED: 50a2fabfdd276f573ff97ace8b11c5f4
+          EXPECTED: ${{ env.EXPECTED_CHECKSUM }}
 
       - run: test "$EXPECTED" = "$ACTUAL"
         env:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           artifact_name: tfplan
+          run_name: plan
           download: true
 
       - run: unzip tfplan.zip

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ one matching artifacts are found.
     # The run name will generally match the job name, but can include additional
     # text if the job run was part of a `matrix` or a reusable workflow
     # Optional
-    # Default: false
+    # Default: ""
     run_name: string
 
     # If true, will download the artifact to the current working directory

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ one matching artifacts are found.
     # Required
     artifact_name: string
 
+    # The name of the run that generated the artifact. This can help narrow the
+    # number of workflow runs that are considered, reducing the chance of
+    # artifact name collisions and reducing the number of necessary API calls.
+    # If not provided, all workflow runs for the provided ref will be considered.
+    # The run name will generally match the job name, but can include additional
+    # text if the job run was part of a `matrix` or a reusable workflow
+    # Optional
+    # Default: false
+    run_name: string
+
     # If true, will download the artifact to the current working directory
     # Optional
     # Default: false

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,14 @@ inputs:
     description: The GitHub token used to create an authenticated client
     required: false
     default: ${{ github.token }}
+  run_name:
+    description: |
+      The name of the run that generated the artifact. This can help narrow the
+      number of workflow runs that are considered, reducing the chance of
+      artifact name collisions and reducing the number of necessary API calls.
+      If not provided, all workflow runs for the provided ref will be considered
+    required: false
+    default: ''
 
 outputs:
   error:

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,9 @@ inputs:
       The name of the run that generated the artifact. This can help narrow the
       number of workflow runs that are considered, reducing the chance of
       artifact name collisions and reducing the number of necessary API calls.
-      If not provided, all workflow runs for the provided ref will be considered
+      If not provided, all workflow runs for the provided ref will be considered.
+      The run name will generally match the job name, but can include additional
+      text if the job run was part of a `matrix` or a reusable workflow
     required: false
     default: ''
 

--- a/index.mjs
+++ b/index.mjs
@@ -64,6 +64,7 @@ async function main() {
   const token = getInput('github_token', { required: true });
   const artifactName = getInput('artifact_name', { required: true });
   const ref = getInput('ref', { required: true });
+  const runName = getInput('run_name', { required: false });
 
   const octokit = getOctokit(
     token,

--- a/index.mjs
+++ b/index.mjs
@@ -101,16 +101,16 @@ function initOctokit(token) {
 }
 
 async function main() {
-  const token = getInput('github_token', { required: true });
-  const artifactName = getInput('artifact_name', { required: true });
-  const ref = getInput('ref', { required: true });
-  const runName = getInput('run_name', { required: false });
+  const octokit = initOctokit(getInput('github_token', { required: true }));
 
-  const octokit = initOctokit(token);
-
-  const workflowIDs = await findWorkflowIDs(octokit, ref, runName)
+  const workflowIDs = await findWorkflowIDs(
+    octokit,
+    getInput('ref', { required: true }),
+    getInput('run_name', { required: false }),
+  )
   const artifacts = await getAllArtifacts(octokit, workflowIDs);
 
+  const artifactName = getInput('artifact_name', { required: true });
   const matchingArtifacts = artifacts.filter((a) => a.name === artifactName);
 
   switch (matchingArtifacts.length) {

--- a/index.mjs
+++ b/index.mjs
@@ -81,13 +81,8 @@ async function downloadArtifact(octokit, { id, name }) {
   return writeFile(`${name}.zip`, Buffer.from(data));
 }
 
-async function main() {
-  const token = getInput('github_token', { required: true });
-  const artifactName = getInput('artifact_name', { required: true });
-  const ref = getInput('ref', { required: true });
-  const runName = getInput('run_name', { required: false });
-
-  const octokit = getOctokit(
+function initOctokit(token) {
+  return getOctokit(
     token,
     {
       throttle: {
@@ -103,6 +98,15 @@ async function main() {
     },
     throttling,
   );
+}
+
+async function main() {
+  const token = getInput('github_token', { required: true });
+  const artifactName = getInput('artifact_name', { required: true });
+  const ref = getInput('ref', { required: true });
+  const runName = getInput('run_name', { required: false });
+
+  const octokit = initOctokit(token);
 
   const workflowIDs = await findWorkflowIDs(octokit, ref, runName)
   const artifacts = await getAllArtifacts(octokit, workflowIDs);

--- a/index.mjs
+++ b/index.mjs
@@ -66,7 +66,8 @@ async function getAllArtifacts(octokit, workflowIDs) {
 async function findWorkflowIDs(octokit, ref, runName) {
   if (runName) {
     const checkRuns = await getCheckRunsForCommit(octokit, ref, runName);
-    return checkRuns.map(checkRunToWorkflowID);
+    const workflowIDs = checkRuns.map(checkRunToWorkflowID);
+    return Array.from(new Set(workflowIDs))
   } else {
     return queryWorkflowIDsForCommit(octokit, ref);
   }

--- a/index.mjs
+++ b/index.mjs
@@ -68,6 +68,15 @@ async function getAllArtifacts(octokit, workflowIDs) {
   ))).then(flatten);
 }
 
+async function findWorkflowIDs(octokit, ref, runName) {
+  if (runName) {
+    const checkRuns = await getCheckRunForCommit(octokit, ref, runName);
+    return checkRuns.map(checkRunToWorkflowID);
+  } else {
+    return queryWorkflowIDsForCommit(octokit, ref);
+  }
+}
+
 async function downloadArtifact(octokit, { id, name }) {
   const { data } = await octokit.rest.actions.downloadArtifact({
     ...context.repo,

--- a/index.mjs
+++ b/index.mjs
@@ -7,7 +7,7 @@ function flatten(xs) {
   return xs.flat();
 }
 
-async function getCheckRunForCommit(octokit, ref, check_name) {
+async function getCheckRunsForCommit(octokit, ref, check_name) {
   return octokit.paginate(octokit.rest.checks.listForRef, {
     ...context.repo,
     ref,
@@ -65,7 +65,7 @@ async function getAllArtifacts(octokit, workflowIDs) {
 
 async function findWorkflowIDs(octokit, ref, runName) {
   if (runName) {
-    const checkRuns = await getCheckRunForCommit(octokit, ref, runName);
+    const checkRuns = await getCheckRunsForCommit(octokit, ref, runName);
     return checkRuns.map(checkRunToWorkflowID);
   } else {
     return queryWorkflowIDsForCommit(octokit, ref);

--- a/index.mjs
+++ b/index.mjs
@@ -20,6 +20,15 @@ async function getCheckRunForCommit(octokit, ref, check_name) {
   });
 }
 
+function checkRunToWorkflowID(checkRun) {
+  const re = "/runs/([^/]+)/job/"
+  const matches = checkRun.details_url.match(re);
+  if (!matches) {
+    throw new Error(`No Workflow ID found for Check Run ${checkRun.id}!`);
+  }
+  return matches[1];
+}
+
 async function queryWorkflowIDsForCommit(octokit, ref) {
   const response = await octokit.graphql(
     `

--- a/index.mjs
+++ b/index.mjs
@@ -72,12 +72,6 @@ async function findWorkflowIDs(octokit, ref, runName) {
   }
 }
 
-async function withAPIUsageLog(octokit, fn) {
-  let start;
-  if (isDebug()) start = await getRemaining(octokit)
-  await fn()
-}
-
 async function downloadArtifact(octokit, { id, name }) {
   const { data } = await octokit.rest.actions.downloadArtifact({
     ...context.repo,

--- a/index.mjs
+++ b/index.mjs
@@ -12,6 +12,14 @@ async function getRemaining(octokit) {
   return parseInt(response.headers['x-ratelimit-used'], 10)
 }
 
+async function getCheckRunForCommit(octokit, ref, check_name) {
+  return octokit.paginate(octokit.rest.checks.listForRef, {
+    ...context.repo,
+    ref,
+    check_name,
+  });
+}
+
 async function queryWorkflowIDsForCommit(octokit, ref) {
   const response = await octokit.graphql(
     `

--- a/index.mjs
+++ b/index.mjs
@@ -110,7 +110,7 @@ async function main() {
   );
 
   const start = await getRemaining(octokit);
-  const workflowIDs = await queryWorkflowIDsForCommit(octokit, ref);
+  const workflowIDs = await findWorkflowIDs(octokit, ref, runName)
   const artifacts = await getAllArtifacts(octokit, workflowIDs);
 
   const matchingArtifacts = artifacts.filter((a) => a.name === artifactName);

--- a/out.js
+++ b/out.js
@@ -24559,7 +24559,8 @@ async function getAllArtifacts(octokit, workflowIDs) {
 async function findWorkflowIDs(octokit, ref, runName) {
   if (runName) {
     const checkRuns = await getCheckRunsForCommit(octokit, ref, runName);
-    return checkRuns.map(checkRunToWorkflowID);
+    const workflowIDs = checkRuns.map(checkRunToWorkflowID);
+    return Array.from(new Set(workflowIDs));
   } else {
     return queryWorkflowIDsForCommit(octokit, ref);
   }

--- a/out.js
+++ b/out.js
@@ -24512,6 +24512,21 @@ throttling.triggersNotification = triggersNotification;
 function flatten(xs) {
   return xs.flat();
 }
+async function getCheckRunsForCommit(octokit, ref, check_name) {
+  return octokit.paginate(octokit.rest.checks.listForRef, {
+    ...import_github.context.repo,
+    ref,
+    check_name
+  });
+}
+function checkRunToWorkflowID(checkRun) {
+  const re = "/runs/([^/]+)/job/";
+  const matches = checkRun.details_url.match(re);
+  if (!matches) {
+    throw new Error(`No Workflow ID found for Check Run ${checkRun.id}!`);
+  }
+  return matches[1];
+}
 async function queryWorkflowIDsForCommit(octokit, ref) {
   const response = await octokit.graphql(
     `
@@ -24541,6 +24556,14 @@ async function getAllArtifacts(octokit, workflowIDs) {
     run_id: id
   }))).then(flatten);
 }
+async function findWorkflowIDs(octokit, ref, runName) {
+  if (runName) {
+    const checkRuns = await getCheckRunsForCommit(octokit, ref, runName);
+    return checkRuns.map(checkRunToWorkflowID);
+  } else {
+    return queryWorkflowIDsForCommit(octokit, ref);
+  }
+}
 async function downloadArtifact(octokit, { id, name }) {
   const { data } = await octokit.rest.actions.downloadArtifact({
     ...import_github.context.repo,
@@ -24549,28 +24572,33 @@ async function downloadArtifact(octokit, { id, name }) {
   });
   return (0, import_promises.writeFile)(`${name}.zip`, Buffer.from(data));
 }
-async function main() {
-  const token = (0, import_core.getInput)("github_token", { required: true });
-  const artifactName = (0, import_core.getInput)("artifact_name", { required: true });
-  const ref = (0, import_core.getInput)("ref", { required: true });
-  const octokit = (0, import_github.getOctokit)(
+function initOctokit(token) {
+  return (0, import_github.getOctokit)(
     token,
     {
       throttle: {
-        onRateLimit(retryAfter, _options, octokit2, retryCount) {
-          octokit2.log.warn("Rate Limit Hit", { retryAfter });
+        onRateLimit(retryAfter, _options, octokit, retryCount) {
+          octokit.log.warn("Rate Limit Hit", { retryAfter });
           if (retryCount < 1) return true;
         },
-        onSecondaryRateLimit(retryAfter, _options, octokit2, retryCount) {
-          octokit2.log.warn("Secondary Rate Limit Hit", { retryAfter });
+        onSecondaryRateLimit(retryAfter, _options, octokit, retryCount) {
+          octokit.log.warn("Secondary Rate Limit Hit", { retryAfter });
           if (retryCount < 1) return true;
         }
       }
     },
     throttling
   );
-  const workflowIDs = await queryWorkflowIDsForCommit(octokit, ref);
+}
+async function main() {
+  const octokit = initOctokit((0, import_core.getInput)("github_token", { required: true }));
+  const workflowIDs = await findWorkflowIDs(
+    octokit,
+    (0, import_core.getInput)("ref", { required: true }),
+    (0, import_core.getInput)("run_name", { required: false })
+  );
   const artifacts = await getAllArtifacts(octokit, workflowIDs);
+  const artifactName = (0, import_core.getInput)("artifact_name", { required: true });
   const matchingArtifacts = artifacts.filter((a) => a.name === artifactName);
   switch (matchingArtifacts.length) {
     case 1: {


### PR DESCRIPTION
Initial testing yielded a 75% decrease in the number of necessary API calls